### PR TITLE
Change multicast Igmp requests to IgmpV3 (RFC 3376). IgmpV3 allows to…

### DIFF
--- a/chipmunk/ctx.c
+++ b/chipmunk/ctx.c
@@ -151,8 +151,8 @@ get_src_info( struct client_ctx* cl, int sockfd )
     }
 
     if( S_ISREG( st.st_mode ) ) {
-        (void) strncpy( cl->src_addr, "File", sizeof(cl->src_addr) );
-        cl->src_addr[ sizeof(cl->src_addr) - 1 ] = '\0';
+        (void) strncpy( cl->mcast_src_addr, "File", sizeof(cl->mcast_src_addr) );
+        cl->mcast_src_addr[ sizeof(cl->mcast_src_addr) - 1 ] = '\0';
         cl->src_port = 0;
     }
     else if( S_ISSOCK( st.st_mode ) ) {
@@ -179,7 +179,7 @@ get_src_info( struct client_ctx* cl, int sockfd )
  */
 int
 add_client( struct server_ctx* ctx,
-            pid_t cpid, const char* maddr, uint16_t mport,
+            pid_t cpid, const char* maddr, const char* msrcaddr, uint16_t mport,
             int sockfd )
 {
     struct client_ctx* client = NULL;
@@ -200,6 +200,9 @@ add_client( struct server_ctx* ctx,
 
     client->mcast_port = mport;
 
+    (void) strncpy( client->mcast_src_addr, msrcaddr, IPADDR_STR_SIZE );
+    client->mcast_src_addr[ IPADDR_STR_SIZE - 1 ] = '\0';
+
     if (ctx->rq.tail[0])
         (void) strcpy( client->tail, ctx->rq.tail );
 
@@ -216,8 +219,8 @@ add_client( struct server_ctx* ctx,
 
     if( g_flog ) {
         (void)tmfprintf( g_flog, "Added client: pid=[%d], maddr=[%s], mport=[%d], "
-                "saddr=[%s], sport=[%d]\n",
-                (int)cpid, maddr, (int)mport, client->src_addr, client->src_port );
+                "msrcaddr=[%s], saddr=[%s], sport=[%d]\n",
+                (int)cpid, maddr, (int)mport, msrcaddr, client->src_addr, client->src_port );
     }
     return 0;
 }

--- a/chipmunk/ctx.h
+++ b/chipmunk/ctx.h
@@ -47,6 +47,7 @@ struct client_ctx
     pid_t       pid;
     char        mcast_addr[ IPADDR_STR_SIZE ];
     uint16_t    mcast_port;
+    char        mcast_src_addr[ IPADDR_STR_SIZE ];
     char        src_addr[ IPADDR_STR_SIZE ];
     uint16_t    src_port;
 
@@ -84,6 +85,8 @@ struct server_ctx
     char        mcast_ifc_addr[ IPADDR_STR_SIZE ];
     struct in_addr
                 mcast_inaddr;
+    struct in_addr
+                mcast_src_inaddr;
 
     struct srv_request rq;  /* (current) request to process */
 
@@ -123,7 +126,7 @@ find_client( const struct server_ctx* ctx, pid_t pid );
  */
 int
 add_client( struct server_ctx* ctx,
-            pid_t cpid, const char* maddr, uint16_t mport,
+            pid_t cpid, const char* maddr, const char* msrcaddr, uint16_t mport,
             int sockfd );
 
 

--- a/chipmunk/netop.c
+++ b/chipmunk/netop.c
@@ -132,20 +132,20 @@ setup_listener( const char* ipaddr, int port, int* sockfd, int bklog )
 /* add or drop membership in a multicast group
  */
 int
-set_multicast( int msockfd, const struct in_addr* mifaddr,
+set_multicast( int msockfd, const struct in_addr* mifaddr, const struct in_addr* srcaddr,
                int opname )
 {
     struct sockaddr_in addr;
     a_socklen_t len = sizeof(addr);
-    struct ip_mreq mreq;
+    struct ip_mreq_source mreq;
 
     int rc = 0;
     const char *opstr =
-        ((IP_DROP_MEMBERSHIP == opname) ? "DROP" :
-         ((IP_ADD_MEMBERSHIP == opname) ? "ADD" : ""));
+        ((IP_DROP_SOURCE_MEMBERSHIP == opname) ? "DROP" :
+         ((IP_ADD_SOURCE_MEMBERSHIP == opname) ? "ADD" : ""));
     assert( opstr[0] );
 
-    assert( (msockfd > 0) && mifaddr );
+    assert( (msockfd > 0) && mifaddr && srcifaddr );
 
     (void) memset( &mreq, 0, sizeof(mreq) );
     (void) memcpy( &mreq.imr_interface, mifaddr,
@@ -160,6 +160,9 @@ set_multicast( int msockfd, const struct in_addr* mifaddr,
 
     (void) memcpy( &mreq.imr_multiaddr, &addr.sin_addr,
                 sizeof(struct in_addr) );
+
+    (void) memcpy( &mreq.imr_sourceaddr, &srcaddr,
+                    sizeof(struct in_addr) );
 
     rc = setsockopt( msockfd, IPPROTO_IP, opname,
                     &mreq, sizeof(mreq) );
@@ -181,6 +184,7 @@ set_multicast( int msockfd, const struct in_addr* mifaddr,
 int
 setup_mcast_listener( struct sockaddr_in*   sa,
                       const struct in_addr* mifaddr,
+                      const struct in_addr* srcaddr,
                       int*                  mcastfd,
                       int                   sockbuflen )
 {
@@ -189,7 +193,7 @@ setup_mcast_listener( struct sockaddr_in*   sa,
     int buflen = sockbuflen;
     size_t rcvbuf_len = 0;
 
-    assert( sa && mifaddr && mcastfd && (sockbuflen >= 0) );
+    assert( sa && mifaddr && srcaddr && mcastfd && (sockbuflen >= 0) );
 
     TRACE( (void)tmfprintf( g_flog, "Setting up multicast listener\n") );
     rc = ERR_INTERNAL;
@@ -241,7 +245,7 @@ setup_mcast_listener( struct sockaddr_in*   sa,
             break;
         }
 
-        rc = set_multicast( sockfd, mifaddr, IP_ADD_MEMBERSHIP );
+        rc = set_multicast( sockfd, mifaddr, srcaddr, IP_ADD_SOURCE_MEMBERSHIP );
         if( 0 != rc )
             break;
     } while(0);
@@ -262,13 +266,13 @@ setup_mcast_listener( struct sockaddr_in*   sa,
 /* unsubscribe from multicast and close the reader socket
  */
 void
-close_mcast_listener( int msockfd, const struct in_addr* mifaddr )
+close_mcast_listener( int msockfd, const struct in_addr* mifaddr, const struct in_addr* srcaddr )
 {
-    assert( mifaddr );
+    assert( mifaddr && srcaddr );
 
     if( msockfd <= 0 ) return;
 
-    (void) set_multicast( msockfd, mifaddr, IP_DROP_MEMBERSHIP );
+    (void) set_multicast( msockfd, mifaddr, srcaddr, IP_DROP_SOURCE_MEMBERSHIP );
     (void) close( msockfd );
 
     TRACE( (void)tmfprintf( g_flog, "Mcast listener socket=[%d] closed\n",
@@ -280,14 +284,14 @@ close_mcast_listener( int msockfd, const struct in_addr* mifaddr )
 /* drop from and add into a multicast group
  */
 int
-renew_multicast( int msockfd, const struct in_addr* mifaddr )
+renew_multicast( int msockfd, const struct in_addr* mifaddr, const struct in_addr* srcaddr )
 {
     int rc = 0;
 
-    rc = set_multicast( msockfd, mifaddr, IP_DROP_MEMBERSHIP );
+    rc = set_multicast( msockfd, mifaddr, srcaddr, IP_DROP_SOURCE_MEMBERSHIP );
     if( 0 != rc ) return rc;
 
-    rc = set_multicast( msockfd, mifaddr, IP_ADD_MEMBERSHIP );
+    rc = set_multicast( msockfd, mifaddr, srcaddr, IP_ADD_SOURCE_MEMBERSHIP );
     return rc;
 }
 

--- a/chipmunk/netop.h
+++ b/chipmunk/netop.h
@@ -42,6 +42,7 @@ setup_listener( const char* ipaddr, int port, int* sockfd, int bklog );
 int
 setup_mcast_listener( struct sockaddr_in*   sa,
                       const struct in_addr* mifaddr,
+		      const struct in_addr* saddr,
                       int*                  mcastfd,
                       int                   sockbuflen );
 
@@ -50,20 +51,20 @@ setup_mcast_listener( struct sockaddr_in*   sa,
  *
  */
 void
-close_mcast_listener( int msockfd, const struct in_addr* mifaddr );
+close_mcast_listener( int msockfd, const struct in_addr* mifaddr, const struct in_addr* srcaddr );
 
 
 /* add or drop membership in a multicast group
  */
 int
-set_multicast( int msockfd, const struct in_addr* mifaddr,
+set_multicast( int msockfd, const struct in_addr* mifaddr, const struct in_addr* srcaddr,
                int opname );
 
 
 /* drop from and add into a multicast group
  */
 int
-renew_multicast( int msockfd, const struct in_addr* mifaddr );
+renew_multicast( int msockfd, const struct in_addr* mifaddr, const struct in_addr* srcaddr );
 
 
 /* set send/receive timeouts on socket(s)

--- a/chipmunk/rparse.c
+++ b/chipmunk/rparse.c
@@ -158,33 +158,45 @@ parse_param( const char* s, size_t slen,
  */
 int
 parse_udprelay( const char*  opt, size_t optlen,
-                char* addr,       size_t addrlen,
+                char* maddr,       size_t maddrlen,
+		char* srcaddr,    size_t srcaddrlen,
                 uint16_t* port )
 {
     int rc = 1;
-    size_t n;
+    size_t n,i;
     int pval;
 
-    const char* SEP = ":%~+-^";
+    const char* SEP1 = "@";
+    const char* SEP2 = ":%~+-^";
     const int MAX_PORT = 65535;
 
     #define MAX_OPTLEN 512
     char s[ MAX_OPTLEN ];
 
-    assert( opt && addr && addrlen && port );
+    assert( opt && addr && addrlen && srcaddr && srcaddrlen && port );
 
     (void) strncpy( s, opt, MAX_OPTLEN );
     s[ MAX_OPTLEN - 1 ] = '\0';
     do {
-        n = strcspn( s, SEP );
-        if( !n || n >= optlen ) break;
-        s[n] = '\0';
 
-        strncpy( addr, s, addrlen );
-        addr[ addrlen - 1 ] ='\0';
+        i = strcspn( s, SEP1 );
+        if( !i || i >= optlen ) break;
+	s[i] = '\0';
+
+        strncpy( srcaddr, s, srcaddrlen );
+        srcaddr[ srcaddrlen  - 1 ] ='\0';
+
+        i++;    
+
+        n = strcspn( s + i, SEP2 );
+        if( !n || n >= optlen ) break;
+        s[i + n] = '\0';
+
+        strncpy( maddr, s + i , maddrlen );
+        maddr[ maddrlen - 1 ] ='\0';
 
         ++n;
-        pval = atoi( s + n );
+        pval = atoi( s + i + n );
         if( (pval > 0) && (pval < MAX_PORT) ) {
             *port = (uint16_t)pval;
         }

--- a/chipmunk/rparse.h
+++ b/chipmunk/rparse.h
@@ -80,7 +80,8 @@ parse_param( const char* s, size_t slen,
  */
 int
 parse_udprelay( const char* opt, size_t optlen,
-                char* addr, size_t addrlen,
+                char* maddr, size_t maddrlen,
+                char* srcaddr, size_t srcaddrlen,
                 uint16_t*       port );
 
 


### PR DESCRIPTION
… specify the IP source address of a multicast streamer. Thus this version of udpxy can be attached to a PIM SSM multicast network (RFC 3569).

Thanks to Pavel for it great work.