### PR TITLE
Use relative links in status page so udpxy can be used with any location

### DIFF
--- a/chipmunk/statpg.h
+++ b/chipmunk/statpg.h
@@ -118,7 +118,7 @@ static const char STAT_PAGE_FMT1[] =
     "    <td>%d</td>\n"
     "</tr>\n"
     "</table>\n"
-    "<form action=\"/restart/\" method=\"get\">\n"
+    "<form action=\"../restart/\" method=\"get\">\n"
     "<input type=\"submit\" value=\"Restart\">\n"
     "</form>\n"
     "\n"
@@ -174,7 +174,7 @@ static const char* ACLIENT_REC_FMT[] = {
 static const char REDIRECT_SCRIPT_FMT[] =
     "<script type=\"text/JavaScript\" language=\"Javascript\">"
     "function body_onload(){"
-    "  var t=setTimeout(\"window.location = '/status'\",%u)"
+    "  var t=setTimeout(\"window.location = '../status/'\",%u)"
     "}"
     "</script>";
 


### PR DESCRIPTION
Hi,

I have noticed that udpxy uses links for status page with the assumption that it will run in root uri. I am combining udpxy with nginx http_secure_link module to enforce some security. For having a convenient path I am using https://<my_domain>/udpxy/<some_params> instead of using https://<my_domain>:4022/<some_params>. Links are absolute and not relative, so it will not work in the first case. This pull request just solves that issue so udpxy status page will work fine in any case.

Kind regards,
Javier