### PR TITLE
Adds basic HTTP Authentication

### DIFF
--- a/chipmunk/Makefile
+++ b/chipmunk/Makefile
@@ -29,9 +29,7 @@ GZIP  := /bin/gzip
 MKDEPOPT := -MM
 DEBUG_ON := -g
 
-CC = gcc
 ACFLAGS = -lm
-
 ALL_CFLAGS = -W -Wall -Werror --pedantic $(CFLAGS)
 
 SYSTEM=$(shell uname 2>/dev/null)

--- a/chipmunk/Makefile
+++ b/chipmunk/Makefile
@@ -29,6 +29,9 @@ GZIP  := /bin/gzip
 MKDEPOPT := -MM
 DEBUG_ON := -g
 
+CC = gcc
+ACFLAGS = -lm
+
 ALL_CFLAGS = -W -Wall -Werror --pedantic $(CFLAGS)
 
 SYSTEM=$(shell uname 2>/dev/null)
@@ -148,7 +151,7 @@ $(DEPFILE): $(SRC)
 
 $(EXEC) : $(DEPFILE) $(OBJ)
 	@rm -f $(EXEC)
-	$(CC) $(CFLAGS) $(LDFLAGS) $(COPT) -o $(EXEC) $(OBJ)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(COPT) -o $(EXEC) $(OBJ) $(ACFLAGS)
 	@ls -l $(EXEC)
 ifneq (yes, $(NO_UDPXREC))
 	@rm -f $(UDPXREC)

--- a/chipmunk/sloop_p.c
+++ b/chipmunk/sloop_p.c
@@ -39,7 +39,8 @@ extern sig_atomic_t must_quit();
 extern void         wait_terminated  (struct server_ctx* ctx);
 extern void         tmout_requests   (tmfd_t* asock, size_t *alen);
 extern void         process_requests (tmfd_t* asock, size_t *alen,
-                                      fd_set* rset, struct server_ctx* srv);
+                                      fd_set* rset, struct server_ctx* srv,
+                                      const char* user_file);
 extern void         accept_requests  (int sockfd, tmfd_t* asock, size_t* alen);
 extern void         terminate_all_clients (struct server_ctx* ctx);
 extern void         wait_all (struct server_ctx* ctx);
@@ -55,7 +56,8 @@ struct server_ctx  g_srv;
 /* process client requests */
 int
 srv_loop( const char* ipaddr, int port,
-             const char* mcast_addr )
+          const char* mcast_addr,
+          const char* user_file )
 {
     int                 rc, maxfd, err, nrdy, i;
     struct in_addr      mcast_inaddr;
@@ -162,7 +164,7 @@ srv_loop( const char* ipaddr, int port,
 
         if ((0 < nasock) &&
                  (0 < (nrdy - (FD_ISSET(g_srv.lsockfd, &rset) ? 1 : 0)))) {
-            process_requests (asock, &nasock, &rset, &g_srv);
+            process_requests (asock, &nasock, &rset, &g_srv, user_file);
             /* n now contains # (yet) unprocessed accepted sockets */
         }
 
@@ -206,4 +208,3 @@ srv_loop( const char* ipaddr, int port,
 
 
 /* __EOF__ */
-


### PR DESCRIPTION
This patch adds basic HTTP Authentication to UDPXY so you can provide a new parameter ```-f <file>``` to udpxy. This file may contain a list of users and password that should be added to the URL in order to get a correct response being protected from sniffers.

Example:

```udpxy -c 20 -T -M 50 -H 10 -R 10 -B 1M -f /etc/udpxy_users.cnf```

Where udpxy_users.cnf should have this format:
```user1:password1
user2:password2
user3:password3
...
userN:passwordN
```

Any of the users will be accepted when calling udpxy:
```http://userX:passwordX@<UDPXY IP>/...```

If the user does not match any of the users defined in udpxy_users.cnf the conection is denied.