### PR TITLE
Add URI prefix support for a simple access control.

### DIFF
--- a/chipmunk/rparse.c
+++ b/chipmunk/rparse.c
@@ -32,6 +32,9 @@
 
 #include "rparse.h"
 #include "mtrace.h"
+#include "uopt.h"
+
+extern struct udpxy_opt g_uopt;
 
 /* parse and copy parameters of HTTP GET request into
  * request buffer
@@ -59,12 +62,19 @@ get_request( const char* src, size_t srclen,
     if( NULL == p ) return 1;   /* no header */
 
     p += (sizeof(HEAD) - 1);
+
+    if( g_uopt.uri_prefix_len ) {
+        if( strncmp(p, g_uopt.uri_prefix, g_uopt.uri_prefix_len) != 0 )
+            return 2;           /* invalid URI prefix */
+        p += g_uopt.uri_prefix_len;
+    }
+
     if( p >= EOD)               /* no request */
-        return 2;
+        return 3;
 
     n = strcspn( p, " " );
     if( (SPACE[0] != p[n]) || ((p + n) > EOD) || (n >= *rqlen) ) /* overflow */
-        return 3;
+        return 4;
 
     (void) strncpy( request, p, n );
     request[ n ] = '\0';

--- a/chipmunk/statpg.h
+++ b/chipmunk/statpg.h
@@ -182,10 +182,10 @@ static const char REQUEST_GUIDE[] =
     "<h3>Available HTTP requests:</h3>\n"
     "<table cellspacing=\"0\">\n"
         "<tr><th>Request template</th><th>Function</th></tr>\n"
-        "<tr><td><small>http://<i>address:port</i>/udp/<i>mcast_addr:mport/</i></small></td>\n"
+        "<tr><td><small>http://<i>address:port</i>/<i>uri_prefix</i>/udp/<i>mcast_addr:mport/</i></small></td>\n"
         "<td>Relay multicast traffic from mcast_addr:mport</td></tr>"
-        "<tr><td><small>http://<i>address:port</i>/status/</small></td><td>Display udpxy status</td></tr>\n"
-        "<tr><td><small>http://<i>address:port</i>/restart/</small></td><td>Restart udpxy</td></tr>\n"
+        "<tr><td><small>http://<i>address:port</i>/<i>uri_prefix</i>/status/</small></td><td>Display udpxy status</td></tr>\n"
+        "<tr><td><small>http://<i>address:port</i>/<i>uri_prefix</i>/restart/</small></td><td>Restart udpxy</td></tr>\n"
     "</table>\n";
 
 

--- a/chipmunk/udpxy.c
+++ b/chipmunk/udpxy.c
@@ -1166,7 +1166,8 @@ usage( const char* app, FILE* fp )
             "\t-H : maximum time (sec) to hold data in buffer "
                     "(-1 = unlimited) [default = %d]\n"
             "\t-n : nice value increment [default = %d]\n"
-            "\t-M : periodically renew multicast subscription (skip if 0 sec) [default = %d sec]\n",
+            "\t-M : periodically renew multicast subscription (skip if 0 sec) [default = %d sec]\n"
+            "\t-u : custom URI prefix for a simple access control [default = none]\n",
             (long)DEFAULT_CACHE_LEN, g_uopt.rbuf_msgs, DHOLD_TIMEOUT, g_uopt.nice_incr,
             (int)g_uopt.mcast_refresh );
     (void) fprintf( fp, "Examples:\n"
@@ -1200,9 +1201,9 @@ udpxy_main( int argc, char* const argv[] )
  * those features are experimental and for dev debugging ONLY
  * */
 #ifdef UDPXY_FILEIO
-    static const char UDPXY_OPTMASK[] = "TvSa:l:p:m:c:B:n:R:r:w:H:M:";
+    static const char UDPXY_OPTMASK[] = "TvSa:l:p:m:c:B:n:R:r:w:H:M:u:";
 #else
-    static const char UDPXY_OPTMASK[] = "TvSa:l:p:m:c:B:n:R:H:M:";
+    static const char UDPXY_OPTMASK[] = "TvSa:l:p:m:c:B:n:R:H:M:u:";
 #endif
 
     struct sigaction qact, iact, cact, oldact;
@@ -1351,6 +1352,16 @@ udpxy_main( int argc, char* const argv[] )
                             rc = ERR_PARAM;
                             break;
                        }
+                      break;
+            case 'u':
+                      g_uopt.uri_prefix_len = snprintf(
+                          g_uopt.uri_prefix, sizeof(g_uopt.uri_prefix), "%s/", optarg);
+                      if( g_uopt.uri_prefix_len >= sizeof(g_uopt.uri_prefix) ) {
+                          (void) fprintf( stderr,
+                              "Too long URI prefix, the limit is %zu chars\n",
+                              sizeof(g_uopt.uri_prefix) - 2 );
+                          rc = ERR_PARAM;
+                      }
                       break;
 
             case ':':

--- a/chipmunk/uopt.c
+++ b/chipmunk/uopt.c
@@ -101,10 +101,14 @@ init_uopt( struct udpxy_opt* uo )
         rc = -1; /* modify rc only if there is an error */
     }
 
+    uo->tcp_nodelay = (flag_t)get_flagval( "UDPXY_TCP_NODELAY", 1);
+
     get_content_type(uo->cnt_type, sizeof(uo->cnt_type));
     assert( uo->cnt_type[0] );
 
-    uo->tcp_nodelay = (flag_t)get_flagval( "UDPXY_TCP_NODELAY", 1);
+    (void) memset(uo->uri_prefix, 0, sizeof(uo->uri_prefix));
+    uo->uri_prefix_len = 0;
+
     return rc;
 }
 

--- a/chipmunk/uopt.h
+++ b/chipmunk/uopt.h
@@ -70,7 +70,10 @@ struct udpxy_opt {
     char    h200_ftr[2048];  /* text to add to HTTP 200 response        */
     flag_t  tcp_nodelay;     /* apply TCP_NODELAY option to
                                 newly-accepted sockets                  */
-    char    cnt_type[80];   /* custom HTTP 200 content type             */
+    char    cnt_type[80];    /* custom HTTP 200 content type            */
+
+    char    uri_prefix[80];  /* custom URI prefix for HTTP requests     */
+    size_t  uri_prefix_len;  /* custom URI prefix length                */
 };
 
 


### PR DESCRIPTION
Hey, Pavel!

I added a simple access control logic by introducing a URI prefix parameter. It should help in situations where a person would like to share IPTV but can't restrict access via a firewall because client IPs are dynamic. I did this for myself and it works great, so I thought that I should share it with the community 😃  .

It works like that:
`udpxy -u helloworld`
`wget http://host:4022/helloworld/status/`
`wget http://host:4022/helloworld/udp/239.1.1.1:1234/`

Why did I bother? Well, one day I opened my router stats and saw that my outgoing traffic was 80+ mbps. Turned out, nowadays a lot of people scan provider networks to find open udpxy instances to watch free IPTV 🤔 .