### PR TITLE
Add support for SSM to udpxy and udpxrec

### DIFF
--- a/chipmunk/README
+++ b/chipmunk/README
@@ -1,5 +1,5 @@
 #
-# Copyright 2008-2012 Pavel V. Cherenkov (pcherenkov@gmail.com)
+# Copyright 2008-2018 Pavel V. Cherenkov (pcherenkov@gmail.com)
 #
 #  This file is part of udpxy.
 #
@@ -74,7 +74,7 @@ connection.
 
 The command to relay traffic is in the format as below:
 
-http://address:port/cmd/mgroup_address[SEP]mgroup_port/
+http://<address>:<port>/<cmd>/[src_address@]<mgroup_address><sep><mgroup_port>/
 
 [SEP] ::= :|%|~|+|-|^
 i.e:
@@ -89,7 +89,8 @@ are acceptable and should all work in the same manner.
 cmd ::= udp | rtp
 
 where ip and port match the listening address/port combination of udpxy,
-and mgroup_address:mgroup_port identify the multicast group to subscribe to.
+and [src_address@]mgroup_address:mgroup_port identify the multicast group
+(and optional source) to subscribe to.
 
 Using 'udp' command will instruct udpxy to probe for known types of payload
 (such as MPEG-TS and RTP over MPEG-TS); using 'rtp' makes udpxy assume RTP

--- a/chipmunk/doc/en/udpxrec.1
+++ b/chipmunk/doc/en/udpxrec.1
@@ -11,7 +11,8 @@ udpxrec \- a programmable multicast traffic recording utility.
 .SH SYNOPSIS
 .B udpxrec
 [\-v] [\-b \fI<begin_time>\fP] [\-e \fI<end_time>\fP] [\-M \fI<maxfilesize>\fP] [\-p \fI<pidfile>\fP] [\-B \fI<bufsizeK>\fP]
-[\-n \fI<nice_incr>\fP] [\-u \fI<seconds_to_wait>\fP] [\-m \fI<mcast_ifc_addr>\fP] [\-l \fI<logfile>\fP] \-c \fI<src_addr>\fP:\fI<port>\fP \fI<dstfile>\fP
+[\-n \fI<nice_incr>\fP] [\-u \fI<seconds_to_wait>\fP] [\-m \fI<mcast_ifc_addr>\fP] [\-l \fI<logfile>\fP]
+[\-s \fI<ssm_source_addr>\fP] \-c \fI<src_addr>\fP:\fI<port>\fP \fI<dstfile>\fP
 
 .SH DESCRIPTION
 .PP
@@ -21,11 +22,14 @@ udpxrec is a utility designed to record (save into a disk file) a segment of mul
 udpxrec accepts the following options:
 
 .TP 8
+.B \-c \fI<src_addr>\fP:\fI<port>\fP
+Channel i.e. multicast address and port from which to record data.
+.TP 8
+.B \-s \fI<ssm_source_addr>\fP
+Optional SSM source address.
+.TP 8
 .B \-v
 Enable verbose output [default = \fIdisabled\fP].
-.TP 8
-.B \-T
-Do NOT run as a daemon [default = \fIdaemon if root\fP].
 .TP 8
 .B \-m \fI<mcast_ifc_addr>\fP
 IPv4 address/interface of (multicast) source [default = \fI0.0.0.0\fP].
@@ -59,9 +63,9 @@ Seconds to wait before updating on how long till recording starts.
 
 .SH EXAMPLES
 .PP
-.B udpxrec \-b 15:45.00 \-e +2:00.00 \-M 1.5Gb \-n 2 \-B 64K \-c 224.0.11.31:5050  /opt/video/tv5.mpg
+.B udpxrec \-b 15:45.00 \-e +2:00.00 \-M 1.5Gb \-n 2 \-B 64K \-s 87.141.215.251  \-c 224.0.11.31:5050  /opt/video/tv5.mpg
 .PP
-Begin recording multicast channel 224.0.11.31:5050 at 15:45 today,
+Begin recording multicast channel 224.0.11.31:5050 from source address 87.141.215.251 at 15:45 today,
 finish recording in two hours or if destination file size >= 1.5 Gb;
 set socket buffer to 64Kb; increment nice value by 2;
 write captured video to /opt/video/tv5.mpg.

--- a/chipmunk/doc/en/udpxy.1
+++ b/chipmunk/doc/en/udpxy.1
@@ -22,9 +22,9 @@ from a given multicast or source-specific multicast subscription to the requesti
 udpxy listens (on a dedicated address/port) for HTTP requests issued by clients.
 A client request should be structured as:
 .PP
-http://{\fIaddress\fP}:{\fIport\fP}/{\fIcmd\fP}/{\fImgroup_address\fP}[\fBSEP\fP]{\fImgroup_port\fP}
+http://{\fIaddress\fP}:{\fIport\fP}/{\fIcmd\fP}/[\fIsrc_address\fP@]{\fImgroup_address\fP}{\fIsep\fP}{\fImgroup_port\fP}
 .TP 8
-.B [SEP]
+.B {sep}
 :|%|~|+|\-|^
 .TP 8
 .B {cmd}

--- a/chipmunk/doc/en/udpxy.1
+++ b/chipmunk/doc/en/udpxy.1
@@ -17,7 +17,7 @@ udpxy \- a UDP-to-HTTP multicast traffic relay daemon.
 .SH DESCRIPTION
 .PP
 udpxy is a \fIUDP-to-HTTP multicast traffic relay daemon\fP: it forwards UDP traffic
-from a given multicast subscription to the requesting HTTP client.
+from a given multicast or source-specific multicast subscription to the requesting HTTP client.
 .PP
 udpxy listens (on a dedicated address/port) for HTTP requests issued by clients.
 A client request should be structured as:
@@ -64,6 +64,8 @@ to close all active connections and restart.
 
 
 .SH EXAMPLES
+.PP
+http://192.168.0.12:5056/udp/10.170.185.82@232.22.137.57:5057
 .PP
 http://192.168.0.12:5056/udp/224.0.2.26:24012
 .PP

--- a/chipmunk/netop.c
+++ b/chipmunk/netop.c
@@ -128,49 +128,58 @@ setup_listener( const char* ipaddr, int port, int* sockfd, int bklog )
     return rc;
 }
 
-
-/* add or drop membership in a multicast group
- */
+/* add or drop membership depending on whether we're dealing with SSM or normal mcast*/
 int
-set_multicast( int msockfd, const struct in_addr* mifaddr,
-               int opname )
+set_multicast( int msockfd, const struct in_addr* mifaddr, const struct in_addr* s_in_addr, char* opname )
 {
     struct sockaddr_in addr;
-    a_socklen_t len = sizeof(addr);
-    struct ip_mreq mreq;
+    /* Structure used for Source-Specific Multicast (RFC 3678) */
+    struct ip_mreq_source group_source_req;
+    /* Structure used for joining or leaving a group multicast IP address */
+    struct ip_mreq group_req;
 
     int rc = 0;
-    const char *opstr =
-        ((IP_DROP_MEMBERSHIP == opname) ? "DROP" :
-         ((IP_ADD_MEMBERSHIP == opname) ? "ADD" : ""));
-    assert( opstr[0] );
+    int mreq_operation = 0;
 
-    assert( (msockfd > 0) && mifaddr );
-
-    (void) memset( &mreq, 0, sizeof(mreq) );
-    (void) memcpy( &mreq.imr_interface, mifaddr,
-                sizeof(struct in_addr) );
-
+    a_socklen_t len = sizeof(addr);
     (void) memset( &addr, 0, sizeof(addr) );
+    (void) memset( &group_source_req, 0, sizeof(group_source_req) );
+    (void) memset( &group_req, 0, sizeof(group_req) );
+
     rc = getsockname( msockfd, (struct sockaddr*)&addr, &len );
+
     if( 0 != rc ) {
         mperror( g_flog, errno, "%s: getsockname", __func__ );
         return -1;
     }
 
-    (void) memcpy( &mreq.imr_multiaddr, &addr.sin_addr,
-                sizeof(struct in_addr) );
+    /*Check for SSM*/
+    if (s_in_addr->s_addr != 0) {
+      mreq_operation = ( ( strcmp("ADD", opname) == 0 ) ? IP_ADD_SOURCE_MEMBERSHIP : ( ( strcmp("DROP", opname) == 0 ) ? IP_DROP_SOURCE_MEMBERSHIP : 69) );
 
-    rc = setsockopt( msockfd, IPPROTO_IP, opname,
-                    &mreq, sizeof(mreq) );
+      /*Fill out the ip_mreq_source struct with the necessary info*/
+      (void) memcpy( &group_source_req.imr_multiaddr, &addr.sin_addr, sizeof(struct in_addr) );
+      (void) memcpy( &group_source_req.imr_sourceaddr, s_in_addr, sizeof(struct in_addr) );
+      (void) memcpy( &group_source_req.imr_interface, mifaddr, sizeof(struct in_addr) );
+      rc = setsockopt( msockfd, IPPROTO_IP, mreq_operation, &group_source_req, sizeof(group_source_req) );
+    }
+    else{
+      mreq_operation = ( ( strcmp("ADD", opname) == 0 ) ? IP_ADD_MEMBERSHIP : ( ( strcmp("DROP", opname) == 0 ) ? IP_DROP_MEMBERSHIP : 69) );
+
+      (void) memcpy( &group_req.imr_multiaddr, &addr.sin_addr, sizeof(struct in_addr) );
+      (void) memcpy( &group_req.imr_interface, mifaddr, sizeof(struct in_addr) );
+      rc = setsockopt( msockfd, IPPROTO_IP, mreq_operation, &group_req, sizeof(group_req) );
+    }
+
     if( 0 != rc ) {
         mperror( g_flog, errno, "%s: setsockopt MCAST option: %s",
-                    __func__, opstr );
+                    __func__, opname );
         return rc;
     }
 
     TRACE( (void)tmfprintf( g_flog, "multicast-group [%s]\n",
-                            opstr ) );
+                            opname ) );
+
     return rc;
 }
 
@@ -179,7 +188,8 @@ set_multicast( int msockfd, const struct in_addr* mifaddr,
  *
  */
 int
-setup_mcast_listener( struct sockaddr_in*   sa,
+setup_mcast_listener( struct sockaddr_in*   s_address,
+                      struct sockaddr_in*   m_address,
                       const struct in_addr* mifaddr,
                       int*                  mcastfd,
                       int                   sockbuflen )
@@ -189,7 +199,7 @@ setup_mcast_listener( struct sockaddr_in*   sa,
     int buflen = sockbuflen;
     size_t rcvbuf_len = 0;
 
-    assert( sa && mifaddr && mcastfd && (sockbuflen >= 0) );
+    assert( s_address && m_address && mifaddr && mcastfd && (sockbuflen >= 0) );
 
     TRACE( (void)tmfprintf( g_flog, "Setting up multicast listener\n") );
     rc = ERR_INTERNAL;
@@ -235,13 +245,13 @@ setup_mcast_listener( struct sockaddr_in*   sa,
         }
 #endif /* SO_REUSEPORT */
 
-        rc = bind( sockfd, (struct sockaddr*)sa, sizeof(*sa) );
+        rc = bind( sockfd, (struct sockaddr*)m_address, sizeof(*m_address) );
         if( 0 != rc ) {
             mperror(g_flog, errno, "%s: bind", __func__);
             break;
         }
 
-        rc = set_multicast( sockfd, mifaddr, IP_ADD_MEMBERSHIP );
+        rc = set_multicast( sockfd, mifaddr, &(s_address->sin_addr), "ADD" );
         if( 0 != rc )
             break;
     } while(0);
@@ -278,13 +288,13 @@ done:
 /* unsubscribe from multicast and close the reader socket
  */
 void
-close_mcast_listener( int msockfd, const struct in_addr* mifaddr )
+close_mcast_listener( int msockfd, const struct in_addr* mifaddr, const struct in_addr* saddr )
 {
     assert( mifaddr );
 
     if( msockfd <= 0 ) return;
 
-    (void) set_multicast( msockfd, mifaddr, IP_DROP_MEMBERSHIP );
+    (void) set_multicast( msockfd, mifaddr, saddr, "DROP" );
     (void) close( msockfd );
 
     TRACE( (void)tmfprintf( g_flog, "Mcast listener socket=[%d] closed\n",
@@ -296,14 +306,14 @@ close_mcast_listener( int msockfd, const struct in_addr* mifaddr )
 /* drop from and add into a multicast group
  */
 int
-renew_multicast( int msockfd, const struct in_addr* mifaddr )
+renew_multicast( int msockfd, const struct in_addr* mifaddr, const struct in_addr* s_in_addr )
 {
     int rc = 0;
 
-    rc = set_multicast( msockfd, mifaddr, IP_DROP_MEMBERSHIP );
+    rc = set_multicast( msockfd, mifaddr, s_in_addr, "DROP" );
     if( 0 != rc ) return rc;
 
-    rc = set_multicast( msockfd, mifaddr, IP_ADD_MEMBERSHIP );
+    rc = set_multicast( msockfd, mifaddr, s_in_addr, "ADD" );
     return rc;
 }
 

--- a/chipmunk/netop.c
+++ b/chipmunk/netop.c
@@ -139,6 +139,7 @@ set_multicast( int msockfd, const struct in_addr* mifaddr, const struct in_addr*
     struct ip_mreq group_req;
 
     int rc = 0;
+    assert( ( strcmp("ADD", opname) == 0 ) ||  ( strcmp("DROP", opname) == 0 ) );
     int mreq_operation = 0;
 
     a_socklen_t len = sizeof(addr);
@@ -155,7 +156,7 @@ set_multicast( int msockfd, const struct in_addr* mifaddr, const struct in_addr*
 
     /*Check for SSM*/
     if (s_in_addr->s_addr != 0) {
-      mreq_operation = ( ( strcmp("ADD", opname) == 0 ) ? IP_ADD_SOURCE_MEMBERSHIP : ( ( strcmp("DROP", opname) == 0 ) ? IP_DROP_SOURCE_MEMBERSHIP : 69) );
+      mreq_operation = ( ( strcmp("ADD", opname) == 0 ) ? IP_ADD_SOURCE_MEMBERSHIP : IP_DROP_SOURCE_MEMBERSHIP );
 
       /*Fill out the ip_mreq_source struct with the necessary info*/
       (void) memcpy( &group_source_req.imr_multiaddr, &addr.sin_addr, sizeof(struct in_addr) );
@@ -164,7 +165,7 @@ set_multicast( int msockfd, const struct in_addr* mifaddr, const struct in_addr*
       rc = setsockopt( msockfd, IPPROTO_IP, mreq_operation, &group_source_req, sizeof(group_source_req) );
     }
     else{
-      mreq_operation = ( ( strcmp("ADD", opname) == 0 ) ? IP_ADD_MEMBERSHIP : ( ( strcmp("DROP", opname) == 0 ) ? IP_DROP_MEMBERSHIP : 69) );
+      mreq_operation = ( ( strcmp("ADD", opname) == 0 ) ? IP_ADD_MEMBERSHIP : IP_DROP_MEMBERSHIP );
 
       (void) memcpy( &group_req.imr_multiaddr, &addr.sin_addr, sizeof(struct in_addr) );
       (void) memcpy( &group_req.imr_interface, mifaddr, sizeof(struct in_addr) );
@@ -174,7 +175,7 @@ set_multicast( int msockfd, const struct in_addr* mifaddr, const struct in_addr*
     if( 0 != rc ) {
         mperror( g_flog, errno, "%s: setsockopt MCAST option: %s",
                     __func__, opname );
-        return rc;
+        return -1;
     }
 
     TRACE( (void)tmfprintf( g_flog, "multicast-group [%s]\n",

--- a/chipmunk/netop.h
+++ b/chipmunk/netop.h
@@ -40,7 +40,8 @@ setup_listener( const char* ipaddr, int port, int* sockfd, int bklog );
  *
  */
 int
-setup_mcast_listener( struct sockaddr_in*   sa,
+setup_mcast_listener( struct sockaddr_in*   s_address,
+                      struct sockaddr_in*   m_address,
                       const struct in_addr* mifaddr,
                       int*                  mcastfd,
                       int                   sockbuflen );
@@ -50,20 +51,20 @@ setup_mcast_listener( struct sockaddr_in*   sa,
  *
  */
 void
-close_mcast_listener( int msockfd, const struct in_addr* mifaddr );
+close_mcast_listener( int msockfd, const struct in_addr* mifaddr, const struct in_addr* s_in_addr );
 
 
 /* add or drop membership in a multicast group
  */
 int
 set_multicast( int msockfd, const struct in_addr* mifaddr,
-               int opname );
+               const struct in_addr* s_in_addr, char* opname );
 
 
 /* drop from and add into a multicast group
  */
 int
-renew_multicast( int msockfd, const struct in_addr* mifaddr );
+renew_multicast( int msockfd, const struct in_addr* mifaddr, const struct in_addr* s_in_addr);
 
 
 /* set send/receive timeouts on socket(s)

--- a/chipmunk/rparse.c
+++ b/chipmunk/rparse.c
@@ -157,12 +157,14 @@ parse_param( const char* s, size_t slen,
  *         non-zero if error
  */
 int
-parse_udprelay( const char*  opt, size_t optlen,
-                char* addr,       size_t addrlen,
+parse_udprelay( const char*  opt,
+                char* s_addr,       size_t s_addrlen,
+                char* m_addr,       size_t m_addrlen,
                 uint16_t* port )
 {
     int rc = 1;
-    size_t n;
+    size_t s_index;
+    size_t m_index;
     int pval;
 
     const char* SEP = ":%~+-^";
@@ -171,32 +173,38 @@ parse_udprelay( const char*  opt, size_t optlen,
     #define MAX_OPTLEN 512
     char s[ MAX_OPTLEN ];
 
-    assert( opt && addr && addrlen && port );
+    assert( opt && s_addr && s_addrlen && m_addr && m_addrlen && port );
 
     (void) strncpy( s, opt, MAX_OPTLEN );
     s[ MAX_OPTLEN - 1 ] = '\0';
-    do {
-        n = strcspn( s, SEP );
-        if( !n || n >= optlen ) break;
-        s[n] = '\0';
+    s_index = strcspn( s, "@" );
 
-        strncpy( addr, s, addrlen );
-        addr[ addrlen - 1 ] ='\0';
-
-        ++n;
-        pval = atoi( s + n );
-        if( (pval > 0) && (pval < MAX_PORT) ) {
-            *port = (uint16_t)pval;
-        }
-        else {
-            rc = 3;
-            break;
-        }
-
-        rc = 0;
+    /*If the n is not the original string size, then we have a match for SSM*/
+    if (s_index != strlen(s)){
+      strncpy( s_addr, s, s_index);
+      s_addr[ s_addrlen - 1 ] ='\0';
+      s[s_index] = '\0';
+      ++s_index;
     }
-    while(0);
+    else{
+      /*Reset the value of n if no SSM was found*/
+      s_index = 0;
+    }
 
+    m_index = strcspn( s + s_index, SEP );
+    strncpy( m_addr, s + s_index , m_index);
+    m_addr[ m_addrlen - 1 ] ='\0';
+    ++m_index;
+
+    pval = atoi( s + s_index + m_index );
+    if( (pval > 0) && (pval < MAX_PORT) ) {
+        *port = (uint16_t)pval;
+    }
+    else {
+        rc = 3;
+    }
+
+    rc = 0;
     return rc;
 }
 

--- a/chipmunk/rparse.h
+++ b/chipmunk/rparse.h
@@ -79,10 +79,11 @@ parse_param( const char* s, size_t slen,
  *         non-zero if error
  */
 int
-parse_udprelay( const char*  opt,
+parse_udprelay( const char* opt, size_t optlen,
                 char* s_addr,       size_t s_addrlen,
-                char* m_addr,       size_t m_addrlen,
-                uint16_t* port );
+                char* addr, size_t addrlen,
+                uint16_t*       port );
+
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/chipmunk/rparse.h
+++ b/chipmunk/rparse.h
@@ -79,10 +79,10 @@ parse_param( const char* s, size_t slen,
  *         non-zero if error
  */
 int
-parse_udprelay( const char* opt, size_t optlen,
-                char* addr, size_t addrlen,
-                uint16_t*       port );
-
+parse_udprelay( const char*  opt,
+                char* s_addr,       size_t s_addrlen,
+                char* m_addr,       size_t m_addrlen,
+                uint16_t* port );
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/chipmunk/statpg.h
+++ b/chipmunk/statpg.h
@@ -184,6 +184,8 @@ static const char REQUEST_GUIDE[] =
         "<tr><th>Request template</th><th>Function</th></tr>\n"
         "<tr><td><small>http://<i>address:port</i>/udp/<i>mcast_addr:mport/</i></small></td>\n"
         "<td>Relay multicast traffic from mcast_addr:mport</td></tr>"
+        "<tr><td><small>http://<i>address:port</i>/udp/<i>source_addr@mcast_addr:mport/</i></small></td>\n"
+        "<td>Relay SSM traffic from source_addr@mcast_addr:mport</td></tr>"
         "<tr><td><small>http://<i>address:port</i>/status/</small></td><td>Display udpxy status</td></tr>\n"
         "<tr><td><small>http://<i>address:port</i>/restart/</small></td><td>Restart udpxy</td></tr>\n"
     "</table>\n";

--- a/chipmunk/udpxrec.c
+++ b/chipmunk/udpxrec.c
@@ -97,7 +97,7 @@ usage( const char* app, FILE* fp )
     (void) fprintf(fp, "%s\n", g_app_info);
     (void) fprintf(fp, "usage: %s [-v] [-b begin_time] [-e end_time] "
             "[-M maxfilesize] [-p pidfile] [-B bufsizeK] [-n nice_incr] "
-            "[-m mcast_ifc_addr] [-l logfile] "
+            "[-m mcast_ifc_addr] [-l logfile] [ -s ssm_addr ]"
             "-c src_addr:port dstfile\n",
             app );
 
@@ -116,6 +116,7 @@ usage( const char* app, FILE* fp )
             "\t-n : nice value increment [default = %d]\n"
             "\t-m : name or address of multicast interface to read from\n"
             "\t-c : multicast channel to record - ipv4addr:port\n"
+            "\t-s : source address for source specific multicast (SSM)\n"
             "\t-l : write output into the logfile\n"
             "\t-u : seconds to wait before updating on how long till recording starts\n",
             g_recopt.nice_incr );
@@ -242,16 +243,23 @@ calc_buf_settings( ssize_t* bufmsgs, size_t* sock_buflen )
 /* subscribe to the (configured) multicast channel
  */
 static int
-subscribe( int* sockfd, struct in_addr* mcast_inaddr )
+subscribe( int* sockfd, struct in_addr* mcast_inaddr, struct sockaddr_in* s_address )
 {
-    /*TODO: Dummy s_address. Need to figure out how to get the source IP in here.*/
-    struct sockaddr_in s_address;
     struct sockaddr_in m_address;
     const char* ipaddr = g_recopt.rec_channel;
+    const char* source_ipaddr = g_recopt.ssm_addr;
     size_t rcvbuf_len = 0;
     int rc = 0;
 
-    assert( sockfd && mcast_inaddr );
+    assert( sockfd && mcast_inaddr && s_address );
+
+    if (strlen(source_ipaddr) != 0 && 1 != inet_aton( source_ipaddr, &s_address->sin_addr)) {
+        mperror( g_flog, errno,
+                "%s: Invalid source address (SSM) [%s]: inet_aton",
+                __func__, source_ipaddr );
+        return -1;
+    }
+    s_address->sin_family = AF_INET;
 
     if( 1 != inet_aton( ipaddr, &m_address.sin_addr ) ) {
         mperror( g_flog, errno,
@@ -273,7 +281,7 @@ subscribe( int* sockfd, struct in_addr* mcast_inaddr )
     rc = calc_buf_settings( NULL, &rcvbuf_len );
     if (0 != rc) return rc;
 
-    return setup_mcast_listener( &s_address, &m_address, mcast_inaddr,
+    return setup_mcast_listener( s_address, &m_address, mcast_inaddr,
             sockfd, (g_recopt.nosync_sbuf ? 0 : rcvbuf_len) );
 }
 
@@ -285,7 +293,7 @@ record()
 {
     int rsock = -1, destfd = -1, rc = 0, wtime_sec = 0;
     struct in_addr raddr;
-    struct in_addr saddr;
+    struct sockaddr_in saddr;
     struct timeval rtv;
     struct dstream_ctx ds;
     ssize_t nmsgs = 0;
@@ -317,7 +325,7 @@ record()
             break;
         }
 
-        rc = subscribe( &rsock, &raddr );
+        rc = subscribe( &rsock, &raddr, &saddr );
         if( 0 != rc ) break;
 
         rtv.tv_sec = RSOCK_TIMEOUT;
@@ -432,7 +440,7 @@ record()
     free_dstream_ctx( &ds );
     if( data ) free( data );
 
-    close_mcast_listener( rsock, &raddr, &saddr );
+    close_mcast_listener( rsock, &raddr, &saddr.sin_addr );
     if( destfd >= 0 ) (void) close( destfd );
 
     if( quit )
@@ -449,7 +457,7 @@ static int
 verify_channel()
 {
     struct in_addr mcast_inaddr;
-    struct in_addr source_inaddr;
+    struct sockaddr_in saddr;
     int sockfd = -1, rc = -1;
     char buf[16];
     ssize_t nrd = -1;
@@ -457,7 +465,7 @@ verify_channel()
 
     static const time_t MSOCK_TMOUT_SEC = 2;
 
-    rc = subscribe( &sockfd, &mcast_inaddr );
+    rc = subscribe( &sockfd, &mcast_inaddr, &saddr );
     do {
         if( rc ) break;
 
@@ -490,7 +498,7 @@ verify_channel()
     } while(0);
 
     if( sockfd >= 0 ) {
-        close_mcast_listener( sockfd, &mcast_inaddr, &source_inaddr );
+      close_mcast_listener( sockfd, &mcast_inaddr, &saddr.sin_addr );
     }
 
     return rc;
@@ -529,7 +537,7 @@ extern int udpxrec_main( int argc, char* const argv[] );
 int udpxrec_main( int argc, char* const argv[] )
 {
     int rc = 0, ch = 0, custom_log = 0, no_daemon = 0;
-    static const char OPTMASK[] = "vb:e:M:p:B:n:m:l:c:R:u:T";
+    static const char OPTMASK[] = "vb:e:M:p:B:n:m:l:c:s:R:u:T";
     time_t now = time(NULL);
     char now_buf[ 32 ] = {0}, sel_buf[ 32 ] = {0}, app_finfo[80] = {0};
 
@@ -671,6 +679,14 @@ int udpxrec_main( int argc, char* const argv[] )
                       if( 0 != rc ) rc = ERR_PARAM;
                       break;
 
+            case 's':
+                      rc = get_ipv4_address( optarg, g_recopt.ssm_addr, sizeof(g_recopt.ssm_addr) );
+                      if( 0 != rc ) {
+                        (void) fprintf( stderr, "Invalid source address (SSM): [%s]\n",
+                                        optarg );
+                          rc = ERR_PARAM;
+                      }
+                      break;
             case 'R':
                       g_recopt.rbuf_msgs = atoi( optarg );
                       if( (g_recopt.rbuf_msgs <= 0) && (-1 != g_recopt.rbuf_msgs) ) {

--- a/chipmunk/udpxy.c
+++ b/chipmunk/udpxy.c
@@ -686,7 +686,7 @@ udp_relay( int sockfd, struct server_ctx* ctx )
     TRACE( (void)tmfprintf( g_flog, "udp_relay : new_socket=[%d] param=[%s]\n",
                         sockfd, ctx->rq.param) );
     do {
-        rc = parse_udprelay( ctx->rq.param, src_addr, IPADDR_STR_SIZE, mcast_addr, IPADDR_STR_SIZE, &port );
+        rc = parse_udprelay( ctx->rq.param, sizeof(ctx->rq.param), src_addr, IPADDR_STR_SIZE, mcast_addr, IPADDR_STR_SIZE, &port );
         if( 0 != rc ) {
             (void) tmfprintf( g_flog, "Error [%d] parsing parameters [%s]\n",
                             rc, ctx->rq.param );

--- a/chipmunk/uopt.h
+++ b/chipmunk/uopt.h
@@ -92,6 +92,7 @@ struct udpxrec_opt {
     char    mcast_addr[ IPADDR_STR_SIZE ];
     char    rec_channel[ IPADDR_STR_SIZE ];
     int     rec_port;
+    char    ssm_addr[ IPADDR_STR_SIZE ];
     int     waitupd_sec;    /* update every N seconds while waiting 
                                to start recording */
 


### PR DESCRIPTION
I have taken commits from @OmegaVVeapon and @squarebracket which are part of OpenLD/udpxy in a reduced form concerning only the changes to add SSM support for udpxy.
I then rewrote parse_udprelay and added SSM support to udpxrec.
I have built an executable on Arch Linux and it works both as udpxy and as udpxrec - udpxrec only works when called with a full absolute path though.