### PR TITLE
Extend the renew multicast subscription feature of udpxy to udpxrec.

### DIFF
--- a/chipmunk/uopt.c
+++ b/chipmunk/uopt.c
@@ -160,6 +160,8 @@ init_recopt( struct udpxrec_opt* ro )
 
     ro->rcv_tmout       = 0;
 
+    ro->mcast_refresh   = DEFAULT_MCAST_REFRESH;
+
     return rc;
 }
 

--- a/chipmunk/uopt.h
+++ b/chipmunk/uopt.h
@@ -88,6 +88,10 @@ struct udpxrec_opt {
     int     rbuf_msgs;      /* max number of messages to save
                                in buffer (-1 = as many as would fit)    */
 
+    u_short mcast_refresh;  /* refresh rate (sec) for multicast
+                               subscription */
+
+
                             /* address of the multicast interface       */
     char    mcast_addr[ IPADDR_STR_SIZE ];
     char    rec_channel[ IPADDR_STR_SIZE ];


### PR DESCRIPTION
This way recordings should not stop unpredictable.