### PR TITLE
Fix write_data() when size 0

### DIFF
--- a/chipmunk/dpkt.c
+++ b/chipmunk/dpkt.c
@@ -743,7 +743,7 @@ write_data( const struct dstream_ctx* spc,
     if( spc->flags & F_SCATTERED ) {
         n_count = spc->pkt_count;
         n = writev( fd, spc->pkt, n_count );
-        if( n <= 0 ) {
+        if( n < 0 ) {
             if( EAGAIN == errno ) {
                 (void)tmfprintf( g_flog, "Write on fd=[%d] timed out\n", fd);
                 error = IO_BLK;
@@ -758,7 +758,7 @@ write_data( const struct dstream_ctx* spc,
             error = n;
     }
 
-    return (n > 0) ? n : error;
+    return (n >= 0) ? n : error;
 }
 
 


### PR DESCRIPTION
When working with RTP packets, if you receive a new network packet without payload then the relay loop is exited. This is not a good behaviour, as you can receive such packets at any time. Thus this patch fixes this permiting the write of 0 bytes inside the function. No side effects are detected, so the patch looks good.