### PR TITLE
Add missing initialization of option -s ssm_addr for udpxrec

### DIFF
--- a/chipmunk/uopt.c
+++ b/chipmunk/uopt.c
@@ -151,6 +151,7 @@ init_recopt( struct udpxrec_opt* ro )
     ro->pidfile         = NULL;
     ro->rec_channel[0]  = '\0';
     ro->rec_port = 0;
+    ro->ssm_addr[0]     = '\0';
     ro->waitupd_sec = -1;
 
     ro->nosync_sbuf  =


### PR DESCRIPTION
Option ssm_addr is always used to determine if SSM is specified and an uninitialized value (non-zero) renders udpxrec unable to receive multicast data because incorrect SSM source is used.