### PR TITLE
Fixed uninitialized source address.

### DIFF
--- a/chipmunk/udpxrec.c
+++ b/chipmunk/udpxrec.c
@@ -283,6 +283,7 @@ subscribe( int* sockfd, struct in_addr* mcast_inaddr, struct sockaddr_in* s_addr
 
     assert( sockfd && mcast_inaddr && s_address );
 
+    memset( s_address, 0, sizeof(struct sockaddr_in) );
     if (strlen(source_ipaddr) != 0 && 1 != inet_aton( source_ipaddr, &s_address->sin_addr)) {
         mperror( g_flog, errno,
                 "%s: Invalid source address (SSM) [%s]: inet_aton",

--- a/chipmunk/udpxy.c
+++ b/chipmunk/udpxy.c
@@ -693,6 +693,7 @@ udp_relay( int sockfd, struct server_ctx* ctx )
             break;
         }
 
+	memset( &src_addr, 0, sizeof(src_addr) );
         /* If the source IP exists, store the IP in the src_addr which is a sockaddr_in struct */
         if( strlen(src_addr) != 0 && 1 != inet_pton(AF_INET, src_addr, &s_addr.sin_addr) ) {
             (void) tmfprintf( g_flog, "Invalid  address: [%s]\n", src_addr );


### PR DESCRIPTION
There is an issue with source specific multicast (SSM) support,
that source address is uninitialized if SSM unspecified.
Which may cause mcast listen with wrong parameter since set_multicast()
requires proper source address indeed.
