### PR TITLE
fix initialization discards 'const' qualifier from pointer target type

### DIFF
--- a/chipmunk/rparse.c
+++ b/chipmunk/rparse.c
@@ -50,7 +50,7 @@ get_request( const char* src, size_t srclen,
              char* request, size_t* rqlen )
 {
     const char HEAD[] = "GET /";
-    char* p = NULL;
+    const char* p = NULL;
     const char* EOD = src + srclen - 1;
     size_t n = 0;
     const char SPACE[] = " ";


### PR DESCRIPTION
Since glibc-2.43:

For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html